### PR TITLE
ISD-5708: Issues with loading iora module

### DIFF
--- a/include/iora/core/config_loader.hpp
+++ b/include/iora/core/config_loader.hpp
@@ -22,7 +22,7 @@ class ConfigLoader
 {
 public:
   /// \brief Constructs and loads a TOML configuration file.
-  explicit ConfigLoader(const std::string &filename) : _filename(filename) {}
+  explicit ConfigLoader(const std::string &filename) : _filename(filename) { load(); }
 
   /// \brief Reloads the configuration from disk.
   bool reload()

--- a/include/iora/iora.hpp
+++ b/include/iora/iora.hpp
@@ -1117,9 +1117,9 @@ protected:
     _webhookServer->setPort(port);
 
     // TLS
-    bool hasTls = _config.server.tls.certFile.has_value() ||
-                  _config.server.tls.keyFile.has_value() || _config.server.tls.caFile.has_value() ||
-                  _config.server.tls.requireClientCert.value_or(false);
+    bool hasTls = _config.server.tls.certFile.has_value() &&
+                  _config.server.tls.keyFile.has_value() &&
+                  _config.server.tls.caFile.has_value();
     if (hasTls)
     {
       IORA_LOG_INFO("applyConfig: TLS is enabled");


### PR DESCRIPTION
- Fixed wrong condition when checking if iora server will load tls or not. Replaced || with &&
- Added loading and parsing of config file in config loaded when contructor is invoked so we dont need to explicitly call load() after creating a instance.